### PR TITLE
Add the option to setup a service using existing playit binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,19 +5,23 @@ A script to set up the [playit.gg](https://playit.gg/) tunnel host and install i
 - Single command installers are nice, particularly when you're dealing with a service.
 - Running anything as a service means that you don't have to have a terminal window open 24/7.  It also means that you can access your server via SSH, view or manage the tunnel, and it will remain running after you close your SSH session.  (That is actually the primary reason I run it as a service.)
 
-Even if you don't want it as a service, this script automates installation so that 
+Even if you don't want it as a service, this script automates installation and ensures that playit is executable, all with a single command!
 
 ## Usage
 ### Debian/Ubuntu, Raspberry Pi (Raspbian)
 The script doesn't need to be run as root, it will elevate permissions when it needs to.
 ```bash
-$ bash <(curl -sS https://raw.githubusercontent.com/aBoredDev/playit-setup-script/main/playit-setup.sh)
+bash <(curl -sS https://raw.githubusercontent.com/aBoredDev/playit-setup-script/main/playit-setup.sh)
 ```
 And that's it!
 
 If you just want to install the tunnel host without setting up a service, use the following command:
 ```bash
-$ bash <(curl -sS https://raw.githubusercontent.com/aBoredDev/playit-setup-script/main/playit-setup.sh) --no-service
+bash <(curl -sS https://raw.githubusercontent.com/aBoredDev/playit-setup-script/main/playit-setup.sh) --no-service
+```
+And if you only want to set up a systemd service for playit, you can use
+```bash
+bash <(curl -sS https://raw.githubusercontent.com/aBoredDev/playit-setup-script/main/playit-setup.sh) --service-only
 ```
 ## Viewing the tunnel host
 To view the tunnel host once it is running as a service, use the following command:

--- a/playit-setup.sh
+++ b/playit-setup.sh
@@ -9,48 +9,74 @@
 # Check the device's architechture
 arch=$( uname -m )
 
-# Check for an existing playit binary in the current directory, and delete it if one exists
-printf "\n\033[04=====m\033[01mChecking for existing playit.gg binaries\033[00m\033[04=====\033[00m\n"
-case $arch in
-    x86_64)
-        if [ -e playit-linux_64-latest ]
-        then
-            printf "Found existing playit binary, deleting...\n"
-            rm playit-linux_64-latest
-        else
-            printf "No existing binaries found\n"
-        fi
-    ;;
-    armv7l)
-        if [ -e playit-armv7-latest ]
-        then
-            printf "Found existing playit binary, deleting...\n"
-            rm playit-armv7-latest
-        else
-            printf "No existing binaries found\n"
-        fi
-        if [ -e playit-linux_64-latest ]
-        then
-            printf "You appear to have downloaded the x86 binary on an arm machine.
-            It will not work!  So we're just going to delete it for you.\n"
-            rm playit-linux_64-latest
-        fi
-    ;;
-esac
-
-# Downloading the latest binary for the correct architecture
-printf "\n\033[04========m\033[01mDownloading latest binary\033[00m\033[04========\033[00m\n"
 name=""
-case $arch in
-    x86_64)
-        wget https://playit.gg/downloads/playit-linux_64-latest
-        chmod +x ./playit-linux_64-latest
-        name='playit-linux_64-latest'
+
+case $1 in
+    --service-only)
+        printf "\n\033[04=====m\033[01mChecking for existing playit.gg binaries\033[00m\033[04=====\033[00m\n"
+        name=$( find . -regex .*/playit.* )
+        name=$( basename -a $name )
+        printf "Possible existing binaries found.  Please select from the following list, or choose other to specify a diiferent binary:\n"
+        select FILE in $name Other
+        do
+            case $FILE in
+                Other)
+                    printf "Enter the name of your playit binary\n"
+                    read name
+                    printf "Using $name\n"
+                ;;
+                *)
+                    printf "Using $FILE\n"
+                    name=$FILE
+                ;;
+            esac
+            break   
+        done
     ;;
-    armv7l)
-        wget https://playit.gg/downloads/playit-armv7-latest
-        chmod +x ./playit-armv7-latest
-        name='playit-armv7-latest'
+    *)
+        # Check for an existing playit binary in the current directory, and delete it if one exists
+        printf "\n\033[04=====m\033[01mChecking for existing playit.gg binaries\033[00m\033[04=====\033[00m\n"
+        case $arch in
+            x86_64)
+                if [ -e playit-linux_64-latest ]
+                then
+                    printf "Found existing playit binary, deleting...\n"
+                    rm playit-linux_64-latest
+                else
+                    printf "No existing binaries found\n"
+                fi
+            ;;
+            armv7l)
+                if [ -e playit-armv7-latest ]
+                then
+                    printf "Found existing playit binary, deleting...\n"
+                    rm playit-armv7-latest
+                else
+                    printf "No existing binaries found\n"
+                fi
+                if [ -e playit-linux_64-latest ]
+                then
+                    printf "You appear to have downloaded the x86 binary on an arm machine.
+                    It will not work!  So we're just going to delete it for you.\n"
+                    rm playit-linux_64-latest
+                fi
+            ;;
+        esac
+    
+        # Downloading the latest binary for the correct architecture
+        printf "\n\033[04========m\033[01mDownloading latest binary\033[00m\033[04========\033[00m\n"
+        case $arch in
+            x86_64)
+                wget https://playit.gg/downloads/playit-linux_64-latest
+                chmod +x ./playit-linux_64-latest
+                name='playit-linux_64-latest'
+            ;;
+            armv7l)
+                wget https://playit.gg/downloads/playit-armv7-latest
+                chmod +x ./playit-armv7-latest
+                name='playit-armv7-latest'
+            ;;
+        esac
     ;;
 esac
 
@@ -90,20 +116,21 @@ To start the tunnel host again at any time, run './$name'\n"
         playit_path=$( pwd )
 
         printf "\nInstalling service file\n"
+        # I know this looks messy, but if I don't do it this way the service file ends up intended
         printf "[Unit]
-        Description=playit.gg tunnel host
-        After=network-online.target
+Description=playit.gg tunnel host
+After=network-online.target
 
-        [Service]
-        Type=forking
-        Restart=no
-        User=$USER
-        WorkingDirectory=$playit_path
-        ExecStart=/usr/bin/screen -d -m -S playit.gg $playit_path/$name
-        ExecStop=/usr/bin/screen -S playit.gg -X quit
+[Service]
+Type=forking
+Restart=no
+User=$USER
+WorkingDirectory=$playit_path
+ExecStart=/usr/bin/screen -d -m -S playit.gg $playit_path/$name
+ExecStop=/usr/bin/screen -S playit.gg -X quit
 
-        [Install]
-        WantedBy=multi-user.target\n" >> ./playit.service
+[Install]
+WantedBy=multi-user.target\n" >> ./playit.service
 
         sudo mv ./playit.service /etc/systemd/system/playit.service
 

--- a/playit-setup.sh
+++ b/playit-setup.sh
@@ -14,9 +14,12 @@ name=""
 case $1 in
     --service-only)
         printf "\n\033[04=====m\033[01mChecking for existing playit.gg binaries\033[00m\033[04=====\033[00m\n"
+        # Look for any files in the current directory which start with 'playit', and strip the ./ off the front
         name=$( find . -regex .*/playit.* )
         name=$( basename -a $name )
-        printf "Possible existing binaries found.  Please select from the following list, or choose other to specify a diiferent binary:\n"
+        
+        # Allow the user to select a binary or specifiy a different one
+        printf "Possible existing binaries found.  Please select from the following list, or choose Other to specify a diiferent binary:\n"
         select FILE in $name Other
         do
             case $FILE in
@@ -57,7 +60,7 @@ case $1 in
                 if [ -e playit-linux_64-latest ]
                 then
                     printf "You appear to have downloaded the x86 binary on an arm machine.
-                    It will not work!  So we're just going to delete it for you.\n"
+It will not work!  So we're just going to delete it for you.\n"
                     rm playit-linux_64-latest
                 fi
             ;;
@@ -144,8 +147,8 @@ WantedBy=multi-user.target\n" >> ./playit.service
 
         # Open screen to show the user the tunnel host, and make sure they know how to exit
         printf "\n\n\nOpening tunnel host now.
-        To exit the tunnel host, do \033[01m\033[04mNOT\033[00m hit Ctrl+c.  Doing so will terminate
-        the tunnel host.  To exit to the terminal, use \033[01mCtrl+a d\033[00m\n"
+To exit the tunnel host, do \033[01m\033[04mNOT\033[00m hit Ctrl+c.  Doing so will terminate
+the tunnel host.  To exit to the terminal, use \033[01mCtrl+a d\033[00m\n"
 
         printf "\nOnce you have read the above, type 'yes' to view the tunnel host\n"
         read confirm
@@ -153,8 +156,8 @@ WantedBy=multi-user.target\n" >> ./playit.service
         do
             printf '\nOpening tunnel host now.\n'
             printf 'To exit the tunnel host, do \033[01m\033[04mNOT\033[00m hit Ctrl+c.
-            Doing so will terminate the tunnel host.  To exit to the terminal, use
-            \033[01mCtrl+a d\033[00m\n'
+Doing so will terminate the tunnel host.  To exit to the terminal, use
+\033[01mCtrl+a d\033[00m\n'
 
             printf "Once you have read the above, type 'yes' to view the tunnel host"
             read confirm
@@ -163,6 +166,6 @@ WantedBy=multi-user.target\n" >> ./playit.service
         screen -r playit.gg
 
         printf "\nTo view the tunnel host at any time, use 'screen -r playit.gg', and
-        \033[01mCtrl+a d\033[00m to return to the terminal\n"
+\033[01mCtrl+a d\033[00m to return to the terminal\n"
     ;;
 esac


### PR DESCRIPTION
This was somewhat bodged together, but hey, it works, and it seems to be fairly reliable.

The script uses find and a bit of regex to check for files which might be playit binaries.  The user is then given a select menu to choose which one they want to use, or they can choose "Other" to specify their own binary that has not been detected.

After that, it just runs the existing code to generate the service file.